### PR TITLE
ci: sp based cluster connection and commit-sha drone semver if missing with kubeconfig fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM mcr.microsoft.com/azure-cli
 RUN apk add --no-cache curl make git bash
 
 # install kubectl

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ steps:
     image: ghcr.io/magna5/k8s-kustomize
     settings:
       image: ghcr.io/magna5/circuit-inventory-service-api
+      cluster: 'M5-Automation'
+      cluster_rg: 'Servers_Prod_Central1'
       azure_appid:
         from_secret: azure_appid
       azure_password:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ Kustomize plugin for Drone CI.
 ```
 steps:
   - name: deploy
-    image: gauravgaglani/k8s-kustomize
+    image: ghcr.io/magna5/k8s-kustomize
     settings:
-      image: docker.pkg.github.com/magna5/companies_master_service/companies_master_service_image
-      kubeconfig:
-        from_secret: kubeconfig
+      image: ghcr.io/magna5/circuit-inventory-service-api
+      azure_appid:
+        from_secret: azure_appid
+      azure_password:
+        from_secret: azure_password
+      azure_tenant:
+        from_secret: azure_tenant
       folderpath: deploy/overlays/production
       debug: true
       dryrun: true

--- a/plugin.sh
+++ b/plugin.sh
@@ -15,7 +15,7 @@ echo ">>> Connecting to the AKS cluster <<<"
 
 ## IF PLUGIN_KUBECONFIG is not passed try connecting to the cluster with `az login...`
 ## otherwise add kubeconfig in the $HOME dierctory to connect with aks cluster
-if [ -z "$PLUGIN_KUBECONFIG" ]; then
+if [ -z "$PLUGIN_KUBECONFIG:-false" ]; then
     ## Auto load cluster config with a couple steps
     ## Step1: Login to az account
     ## Step2: Load the cluster config to connect the connection

--- a/plugin.sh
+++ b/plugin.sh
@@ -11,14 +11,7 @@ set -eu pipefail
 
 "${PLUGIN_DEBUG:-false}" && set -x && printenv
 
-## Check if the folderpath for manifests is present
-echo ">>> Checking for k8s manifests directory path <<<"
-if [ -z "$PLUGIN_FOLDERPATH" ]; then
-    echo "KUBECONFIG and/or FOLDERPATH not supplied"
-    exit 1
-fi
-
-echo ">>> Adding AKS cluster config for connection <<<"
+echo ">>> Connecting to the AKS cluster <<<"
 
 ## IF PLUGIN_KUBECONFIG is not passed try connecting to the cluster with `az login...`
 ## otherwise add kubeconfig in the $HOME dierctory to connect with aks cluster
@@ -50,11 +43,18 @@ if [ -z "$PLUGIN_KUBECONFIG" ]; then
         fi
     fi
 else
-    echo ">>> Setting kubeconfig to access the k8s cluster <<<"
+    echo ">>> Copying kubeconfig to access the k8s cluster <<<"
     [ -d $HOME/.kube ] || mkdir $HOME/.kube
     echo "# Plugin PLUGIN_KUBECONFIG available" >&2
     echo "$PLUGIN_KUBECONFIG" > $HOME/.kube/config
     unset PLUGIN_KUBECONFIG
+fi
+
+## Check if the folderpath for manifests is present
+echo ">>> Checking for k8s manifests directory path <<<"
+if [ -z "$PLUGIN_FOLDERPATH" ]; then
+    echo "KUBECONFIG and/or FOLDERPATH not supplied"
+    exit 1
 fi
 
 cd "${PLUGIN_FOLDERPATH}"

--- a/plugin.sh
+++ b/plugin.sh
@@ -18,32 +18,43 @@ if [ -z "$PLUGIN_FOLDERPATH" ]; then
     exit 1
 fi
 
-## Auto load cluster config with a couple steps
-## Step1: Login to az account
-## Step2: Load the cluster config to connect the connection
-echo ">>> Adding AKS cluster as config for connection <<<"
+echo ">>> Adding AKS cluster config for connection <<<"
 
-echo ">>> Signing into Azure <<<"
-az login --service-principal -u ${PLUGIN_AZURE_APPID} -p ${PLUGIN_AZURE_PASSWORD} --tenant ${PLUGIN_AZURE_TENANT} || exit 1
+## IF PLUGIN_KUBECONFIG is not passed try connecting to the cluster with `az login...`
+## otherwise add kubeconfig in the $HOME dierctory to connect with aks cluster
+if [ -z "$PLUGIN_KUBECONFIG" ]; then
+    ## Auto load cluster config with a couple steps
+    ## Step1: Login to az account
+    ## Step2: Load the cluster config to connect the connection
 
-echo ">>> Adding Cluster $HOME/.kube/config <<<"
-az aks get-credentials --name ${PLUGIN_CLUSTER} --resource-group ${PLUGIN_CLUSTER_RG} || exit 1
+    echo ">>> Signing into Azure <<<"
+    az login --service-principal -u ${PLUGIN_AZURE_APPID} -p ${PLUGIN_AZURE_PASSWORD} --tenant ${PLUGIN_AZURE_TENANT} || exit 1
 
-echo ">>> Checking for the deployment operation to be performed. It could be DB migration job or k8s resource deployment like: deployment or namespace <<<"
+    echo ">>> Adding Cluster $HOME/.kube/config <<<"
+    az aks get-credentials --name ${PLUGIN_CLUSTER} --resource-group ${PLUGIN_CLUSTER_RG} || exit 1
 
-## Delete the existing `migration` job if it exists.
-## New migrations cannot be deployed without deleting the existing one.
-PLUGIN_MIGRATION_JOB="${PLUGIN_MIGRATION_JOB:-false}"
-if [ $PLUGIN_MIGRATION_JOB == true ]
-    then
-    PLUGIN_NAMESPACE="${PLUGIN_NAMESPACE:-default}"
-    if [ PLUGIN_NAMESPACE != "default" ]
+    echo ">>> Checking for the deployment operation to be performed. It could be DB migration job or k8s resource deployment like: deployment or namespace <<<"
+
+    ## Delete the existing `migration` job if it exists.
+    ## New migrations cannot be deployed without deleting the existing one.
+    PLUGIN_MIGRATION_JOB="${PLUGIN_MIGRATION_JOB:-false}"
+    if [ $PLUGIN_MIGRATION_JOB == true ]
         then
-        echo ">>> Deleting the existing DB migration Job resource: ${PLUGIN_JOBNAME} in Namespace: ${PLUGIN_NAMESPACE}. <<<"
-        kubectl delete -n ${PLUGIN_NAMESPACE} job/${PLUGIN_JOBNAME} || true
-    else
-        echo ">>> Error: No namespace defined for the migration job. <<<"
+        PLUGIN_NAMESPACE="${PLUGIN_NAMESPACE:-default}"
+        if [ PLUGIN_NAMESPACE != "default" ]
+            then
+            echo ">>> Deleting the existing DB migration Job resource: ${PLUGIN_JOBNAME} in Namespace: ${PLUGIN_NAMESPACE}. <<<"
+            kubectl delete -n ${PLUGIN_NAMESPACE} job/${PLUGIN_JOBNAME} || true
+        else
+            echo ">>> Error: No namespace defined for the migration job. <<<"
+        fi
     fi
+else
+    echo ">>> Setting kubeconfig to access the k8s cluster <<<"
+    [ -d $HOME/.kube ] || mkdir $HOME/.kube
+    echo "# Plugin PLUGIN_KUBECONFIG available" >&2
+    echo "$PLUGIN_KUBECONFIG" > $HOME/.kube/config
+    unset PLUGIN_KUBECONFIG
 fi
 
 cd "${PLUGIN_FOLDERPATH}"


### PR DESCRIPTION
This commit changes sp based aks cluster connection based on the azure_id, azure_password, azure_tenant plugin variables. Also, the DRONE_SEMVER and DRONE_TAG variables when not passed then commit-sha is set as DRONE_SEMVER and DRONE_TAG. 

Closes [ch-5611]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/magna5/drone-k8s-kustomize/2)
<!-- Reviewable:end -->
