### PR TITLE
fix: set the az account with the right subscription id to load the k8s cluster config

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -25,7 +25,7 @@ if [ -z "$PLUGIN_KUBECONFIG" ]; then
     echo ">>> Signing into Azure <<<"
     az login --service-principal -u ${PLUGIN_AZURE_APPID} -p ${PLUGIN_AZURE_PASSWORD} --tenant ${PLUGIN_AZURE_TENANT} || exit 1
 
-    echo ">>> Setting the az account with the right subscription id<<<"
+    echo ">>> Setting the az account with the right subscription id <<<"
     SUBSCRIPTION_ID=${PLUGIN_SUBSCRIPTION_ID:-"5b1538d5-2945-421f-92c2-9431ef5a283d"}
     az account set --subscription $SUBSCRIPTION_ID
 

--- a/plugin.sh
+++ b/plugin.sh
@@ -19,14 +19,31 @@ PLUGIN_KUBECONFIG=${PLUGIN_KUBECONFIG:-''}
 if [ -z "$PLUGIN_KUBECONFIG" ]; then
     ## Auto load cluster config with a couple steps
     ## Step1: Login to az account
-    ## Step2: Load the cluster config to connect the connection
+    ## Step2: Set the az account subscription(s) and
+    ## Step3: Load the cluster config to connect to the cluster if the account is set with the right subscription_id id
 
     echo ">>> Signing into Azure <<<"
     az login --service-principal -u ${PLUGIN_AZURE_APPID} -p ${PLUGIN_AZURE_PASSWORD} --tenant ${PLUGIN_AZURE_TENANT} || exit 1
 
-    echo ">>> Adding Cluster $HOME/.kube/config <<<"
-    az aks get-credentials --name ${PLUGIN_CLUSTER} --resource-group ${PLUGIN_CLUSTER_RG} || exit 1
+    echo ">>> Fetching and Setting Subscription IDs for the account <<<"
+    declare -a SUBSCRIPTION_IDS
+    SUBSCRIPTION_IDS=$(az account list --query "[].id" -o tsv)
 
+    for subscription in $SUBSCRIPTION_IDS
+        do
+            echo "Setting the az account with Subscription ID: $subscription"
+            az account set --subscription $subscription
+
+            echo ">>> Adding Cluster Config at $HOME/.kube/config <<<"
+            az aks get-credentials --name ${PLUGIN_CLUSTER} --resource-group ${PLUGIN_CLUSTER_RG}
+
+            if [ $? != 0 ]; then
+                echo "Breaking..."
+                break
+            else
+                echo "Fail to add the k8s cluster config because of inappropriate subscription_id"
+            fi
+    done
 else
     echo ">>> Copying kubeconfig to access the k8s cluster <<<"
     [ -d $HOME/.kube ] || mkdir $HOME/.kube


### PR DESCRIPTION
This commit adds a fix to set the az account with the right subscription id before loading the right k8s config which fixes the original error of cluster connection. The account subscription required to connect to the cluster is not the default one which leads to the cluster connection error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ringsq/drone-k8s-kustomize/5)
<!-- Reviewable:end -->
